### PR TITLE
Ability to use the NoLocal flag on ISession.CreateConsumer() calls

### DIFF
--- a/Obvs.ActiveMQ.Tests/TestMessageSource.cs
+++ b/Obvs.ActiveMQ.Tests/TestMessageSource.cs
@@ -52,7 +52,7 @@ namespace Obvs.ActiveMQ.Tests
             _acknowledgementMode = AcknowledgementMode.AutoAcknowledge;
 
             A.CallTo(() => _connection.CreateSession(A<Apache.NMS.AcknowledgementMode>.Ignored)).Returns(_session);
-            A.CallTo(() => _session.CreateConsumer(_destination)).Returns(_consumer);
+            A.CallTo(() => _session.CreateConsumer(_destination, null, false)).Returns(_consumer);
 
             _source = new MessageSource<ITestMessage>(_lazyConnection, new[] {_deserializer}, _destination,
                 _acknowledgementMode);
@@ -72,7 +72,7 @@ namespace Obvs.ActiveMQ.Tests
             _source.Messages.Subscribe(_observer);
 
             A.CallTo(() => _connection.CreateSession(_acknowledgementMode == AcknowledgementMode.ClientAcknowledge ? Apache.NMS.AcknowledgementMode.ClientAcknowledge : Apache.NMS.AcknowledgementMode.AutoAcknowledge)).MustHaveHappened(Repeated.Exactly.Once);
-            A.CallTo(() => _session.CreateConsumer(_destination)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _session.CreateConsumer(_destination, null, false)).MustHaveHappened(Repeated.Exactly.Once);
 
             A.CallTo(_consumer).Where(x => x.Method.Name.Equals("add_Listener")).MustHaveHappened();
         }
@@ -97,7 +97,7 @@ namespace Obvs.ActiveMQ.Tests
                 AcknowledgementMode.ClientAcknowledge);
 
             var consumer = A.Fake<IMessageConsumer>();
-            A.CallTo(() => _session.CreateConsumer(_destination)).Returns(consumer);
+            A.CallTo(() => _session.CreateConsumer(_destination, null, false)).Returns(consumer);
 
             IBytesMessage bytesMessage = A.Fake<IBytesMessage>();
             A.CallTo(() => _deserializer.Deserialize(A<Stream>.Ignored)).Throws<Exception>();
@@ -115,8 +115,8 @@ namespace Obvs.ActiveMQ.Tests
                 AcknowledgementMode.ClientAcknowledge);
 
             var consumer = A.Fake<IMessageConsumer>();
-            A.CallTo(() => _session.CreateConsumer(_destination)).Returns(consumer);
-
+            A.CallTo(() => _session.CreateConsumer(_destination, null, false)).Returns(consumer);
+            
             ITextMessage textMessage = A.Fake<ITextMessage>();
 
             _source.Messages.Subscribe(_observer);
@@ -129,7 +129,7 @@ namespace Obvs.ActiveMQ.Tests
         public void ShouldDeserializeAndPublishMessageWhenReceived()
         {
             var consumer = A.Fake<IMessageConsumer>();
-            A.CallTo(() => _session.CreateConsumer(_destination)).Returns(consumer);
+            A.CallTo(() => _session.CreateConsumer(_destination, null, false)).Returns(consumer);
 
             IBytesMessage bytesMessage = A.Fake<IBytesMessage>();
             ITestMessage message = A.Fake<ITestMessage>();
@@ -150,7 +150,7 @@ namespace Obvs.ActiveMQ.Tests
         public void ShouldDeserializeByteMessagesAndPublishMessageWhenReceived()
         {
             var consumer = A.Fake<IMessageConsumer>();
-            A.CallTo(() => _session.CreateConsumer(_destination)).Returns(consumer);
+            A.CallTo(() => _session.CreateConsumer(_destination, null, false)).Returns(consumer);
 
             IBytesMessage bytesMessage = A.Fake<IBytesMessage>();
             ITestMessage message = A.Fake<ITestMessage>();
@@ -168,7 +168,7 @@ namespace Obvs.ActiveMQ.Tests
         public void ShouldDeserializeAndPublishMessageOfRightTypeName()
         {
             var consumer = A.Fake<IMessageConsumer>();
-            A.CallTo(() => _session.CreateConsumer(_destination)).Returns(consumer);
+            A.CallTo(() => _session.CreateConsumer(_destination, null, false)).Returns(consumer);
 
             IBytesMessage bytesMessage = A.Fake<IBytesMessage>();
             ITestMessage message = A.Fake<ITestMessage>();
@@ -195,7 +195,7 @@ namespace Obvs.ActiveMQ.Tests
         public void ShouldProcessMessagesWithoutTypeNameIfOnlyOneDeserializerSupplied()
         {
             var consumer = A.Fake<IMessageConsumer>();
-            A.CallTo(() => _session.CreateConsumer(_destination)).Returns(consumer);
+            A.CallTo(() => _session.CreateConsumer(_destination, null, false)).Returns(consumer);
 
             IBytesMessage bytesMessage = A.Fake<IBytesMessage>();
             ITestMessage message = A.Fake<ITestMessage>();
@@ -223,7 +223,7 @@ namespace Obvs.ActiveMQ.Tests
             const string typeName = "SomeTypeName";
 
             var consumer = A.Fake<IMessageConsumer>();
-            A.CallTo(() => _session.CreateConsumer(_destination)).Returns(consumer);
+            A.CallTo(() => _session.CreateConsumer(_destination, null, false)).Returns(consumer);
 
             IBytesMessage bytesMessage = A.Fake<IBytesMessage>();
             ITestMessage message = A.Fake<ITestMessage>();
@@ -242,7 +242,7 @@ namespace Obvs.ActiveMQ.Tests
             A.CallTo(() => _deserializer.GetTypeName()).Returns(typeName);
 
             _source = new MessageSource<ITestMessage>(_lazyConnection, new[] {_deserializer}, _destination,
-                _acknowledgementMode, null, filter);
+                _acknowledgementMode, null, false, filter);
 
             _source.Messages.Subscribe(_observer);
             consumer.Listener += Raise.FreeForm.With((Apache.NMS.IMessage) bytesMessage);

--- a/Obvs.ActiveMQ/Configuration/ActiveMQFluentConfig.cs
+++ b/Obvs.ActiveMQ/Configuration/ActiveMQFluentConfig.cs
@@ -109,6 +109,7 @@ namespace Obvs.ActiveMQ.Configuration
         private Func<IDictionary, bool> _propertyFilter;
         private string _brokerSelector;
         private Func<TMessage, Dictionary<string, object>> _propertyProvider;
+        private bool _noLocal;
         private string _userName;
         private string _password;
         private Action<ConnectionFactory> _connectionFactoryConfiguration;
@@ -131,6 +132,12 @@ namespace Obvs.ActiveMQ.Configuration
             return this;
         }
 
+        public ICanCreateEndpointAsClientOrServer<TMessage, TCommand, TEvent, TRequest, TResponse> NoLocal()
+        {
+            _noLocal = true;
+            return this;
+        }
+
         public ICanAddEndpointOrLoggingOrCorrelationOrCreate<TMessage, TCommand, TEvent, TRequest, TResponse> AsClient()
         {
             return _canAddEndpoint.WithClientEndpoints(CreateProvider());
@@ -150,7 +157,7 @@ namespace Obvs.ActiveMQ.Configuration
         {
             return new ActiveMQServiceEndpointProvider<TServiceMessage, TMessage, TCommand, TEvent, TRequest, TResponse>(
                 _serviceName, _brokerUri, _serializer, _deserializerFactory, _queueTypes, _assemblyFilter, 
-                _typeFilter, ActiveMQFluentConfigContext.SharedConnection, _brokerSelector, _propertyFilter,
+                _typeFilter, ActiveMQFluentConfigContext.SharedConnection, _brokerSelector, _noLocal, _propertyFilter,
                 _propertyProvider, _userName, _password, _connectionFactoryConfiguration);
         }
 

--- a/Obvs.ActiveMQ/Configuration/ActiveMQServiceEndpointProvider.cs
+++ b/Obvs.ActiveMQ/Configuration/ActiveMQServiceEndpointProvider.cs
@@ -27,6 +27,7 @@ namespace Obvs.ActiveMQ.Configuration
         private readonly Func<Assembly, bool> _assemblyFilter;
         private readonly Func<Type, bool> _typeFilter;
         private readonly string _selector;
+        private readonly bool _noLocal;
         private readonly Func<IDictionary, bool> _propertyFilter;
         private readonly Func<TMessage, Dictionary<string, object>> _propertyProvider;
         private readonly Lazy<IConnection> _endpointConnection;
@@ -41,6 +42,7 @@ namespace Obvs.ActiveMQ.Configuration
             Func<Type, bool> typeFilter = null,
             Lazy<IConnection> sharedConnection = null,
             string selector = null,
+            bool noLocal = false,
             Func<IDictionary, bool> propertyFilter = null,
             Func<TMessage, Dictionary<string, object>> propertyProvider = null,
             string userName = null,
@@ -54,6 +56,7 @@ namespace Obvs.ActiveMQ.Configuration
             _assemblyFilter = assemblyFilter;
             _typeFilter = typeFilter;
             _selector = selector;
+            _noLocal = noLocal;
             _propertyFilter = propertyFilter;
             _propertyProvider = propertyProvider;
 
@@ -106,7 +109,7 @@ namespace Obvs.ActiveMQ.Configuration
                 var topicSources = new[]
                 {
                     new MessageSource<T>(connection, deserializers, new ActiveMQTopic(destination),
-                        acknowledgementMode, _selector, _propertyFilter)
+                        acknowledgementMode, _selector, _noLocal, _propertyFilter)
                 };
                 var queueSources = queueTypes.Select(qt =>
                     new MessageSource<T>(connection,
@@ -114,13 +117,14 @@ namespace Obvs.ActiveMQ.Configuration
                         new ActiveMQQueue(GetTypedQueueName(destination, qt.Item1)),
                         qt.Item2,
                         _selector,
+                        _noLocal,
                         _propertyFilter));
 
                 return new MergedMessageSource<T>(topicSources.Concat(queueSources));
             }
 
             return DestinationFactory.CreateSource<T, TServiceMessage>(connection, destination, GetDestinationType<T>(),
-                _deserializerFactory, _propertyFilter, _assemblyFilter, _typeFilter, _selector,
+                _deserializerFactory, _propertyFilter, _assemblyFilter, _typeFilter, _selector, _noLocal,
                 acknowledgementMode);
         }
 

--- a/Obvs.ActiveMQ/Configuration/DestinationFactory.cs
+++ b/Obvs.ActiveMQ/Configuration/DestinationFactory.cs
@@ -38,14 +38,15 @@ namespace Obvs.ActiveMQ.Configuration
         }
 
         public static MessageSource<TMessage> CreateSource<TMessage, TServiceMessage>(
-            Lazy<IConnection> lazyConnection, 
-            string destination, 
-            DestinationType destinationType, 
-            IMessageDeserializerFactory deserializerFactory, 
-            Func<IDictionary, bool> propertyFilter, 
-            Func<Assembly, bool> assemblyFilter = null, 
-            Func<Type, bool> typeFilter = null, 
-            string selector = null, 
+            Lazy<IConnection> lazyConnection,
+            string destination,
+            DestinationType destinationType,
+            IMessageDeserializerFactory deserializerFactory,
+            Func<IDictionary, bool> propertyFilter,
+            Func<Assembly, bool> assemblyFilter = null,
+            Func<Type, bool> typeFilter = null,
+            string selector = null,
+            bool noLocal = false,
             AcknowledgementMode mode = AcknowledgementMode.AutoAcknowledge)
             where TMessage : class
             where TServiceMessage : class
@@ -54,7 +55,7 @@ namespace Obvs.ActiveMQ.Configuration
                 lazyConnection,
                 deserializerFactory.Create<TMessage, TServiceMessage>(assemblyFilter, typeFilter),
                 CreateDestination(destination, destinationType),
-                mode, selector, propertyFilter);
+                mode, selector, noLocal, propertyFilter);
         }
 
         private static IDestination CreateDestination(string name, DestinationType type)

--- a/Obvs.ActiveMQ/Extensions/SessionExtensions.cs
+++ b/Obvs.ActiveMQ/Extensions/SessionExtensions.cs
@@ -7,12 +7,13 @@ namespace Obvs.ActiveMQ.Extensions
 {
     internal static class SessionExtensions
     {
-        public static IObservable<IMessage> ToObservable(this ISession session, IDestination destination, string selector = null)
+        public static IObservable<IMessage> ToObservable(this ISession session, IDestination destination, string selector = null, bool noLocal = false)
         {
             return Observable.Create<IMessage>(
                 observer =>
                 {
-                    var consumer = string.IsNullOrEmpty(selector) ? session.CreateConsumer(destination) : session.CreateConsumer(destination, selector);
+                    var consumer = session.CreateConsumer(destination, selector, noLocal);
+                    
                     consumer.Listener += observer.OnNext;
 
                     return Disposable.Create(

--- a/Obvs.ActiveMQ/TextMessageSource.cs
+++ b/Obvs.ActiveMQ/TextMessageSource.cs
@@ -17,9 +17,9 @@ namespace Obvs.ActiveMQ
         private readonly Encoding _encoding;
 
         public TextMessageSource(Lazy<IConnection> lazyConnection, IEnumerable<IMessageDeserializer<TMessage>> deserializers,
-            IDestination destination, AcknowledgementMode mode = AcknowledgementMode.AutoAcknowledge, string selector = null, 
+            IDestination destination, AcknowledgementMode mode = AcknowledgementMode.AutoAcknowledge, string selector = null, bool noLocal = false,
             Encoding encoding = null, Func<IDictionary, bool> propertyFilter = null)
-            : base(lazyConnection, deserializers, destination, mode, selector, propertyFilter)
+            : base(lazyConnection, deserializers, destination, mode, selector, noLocal, propertyFilter)
         {
             _encoding = encoding ?? Encoding.UTF8;
         }


### PR DESCRIPTION
On ActiveMQ's `Session` object, it's possible to set a `NoLocal` flag when creating a new consumer that prevents messages sent to the bus to be delivered back to the consumer.

It's useful if we know our messages will never be handled in the scope of the consumer connection, for example:
* fire and forget messages
* messages that we know for sure are handled by another process