### PR TITLE
Follow-up fixes for the previous PR introducing the NoLocal flag

### DIFF
--- a/Obvs.ActiveMQ.Tests/TestMessageSource.cs
+++ b/Obvs.ActiveMQ.Tests/TestMessageSource.cs
@@ -242,7 +242,7 @@ namespace Obvs.ActiveMQ.Tests
             A.CallTo(() => _deserializer.GetTypeName()).Returns(typeName);
 
             _source = new MessageSource<ITestMessage>(_lazyConnection, new[] {_deserializer}, _destination,
-                _acknowledgementMode, null, false, filter);
+                _acknowledgementMode, null, filter, false);
 
             _source.Messages.Subscribe(_observer);
             consumer.Listener += Raise.FreeForm.With((Apache.NMS.IMessage) bytesMessage);

--- a/Obvs.ActiveMQ/Configuration/ActiveMQFluentConfig.cs
+++ b/Obvs.ActiveMQ/Configuration/ActiveMQFluentConfig.cs
@@ -51,8 +51,9 @@ namespace Obvs.ActiveMQ.Configuration
 
     public interface ICanSpecifyActiveMQBroker<TMessage, TCommand, TEvent, TRequest, TResponse> : 
         ICanSpecifyActiveMQQueue<TMessage, TCommand, TEvent, TRequest, TResponse>,
-        ICanSpecifyActiveMQMessageFiltering<TMessage, TCommand, TEvent, TRequest, TResponse>, 
-        ICanSpecifyEndpointSerializers<TMessage, TCommand, TEvent, TRequest, TResponse>
+        ICanSpecifyActiveMQMessageFiltering<TMessage, TCommand, TEvent, TRequest, TResponse>,
+        ICanSpecifyEndpointSerializers<TMessage, TCommand, TEvent, TRequest, TResponse>,
+        ICanSpecifyActiveMQNoLocalFlag<TMessage, TCommand, TEvent, TRequest, TResponse>
         where TMessage : class
         where TCommand : class, TMessage
         where TEvent : class, TMessage
@@ -86,11 +87,22 @@ namespace Obvs.ActiveMQ.Configuration
         ICanSpecifyActiveMQBroker<TMessage, TCommand, TEvent, TRequest, TResponse> AppendMessageProperties(Func<TMessage, Dictionary<string, object>> propertyProvider);
     }
 
+    public interface ICanSpecifyActiveMQNoLocalFlag<TMessage, TCommand, TEvent, TRequest, TResponse>
+        where TMessage : class
+        where TCommand : class, TMessage
+        where TEvent : class, TMessage
+        where TRequest : class, TMessage
+        where TResponse : class, TMessage
+    {
+        ICanSpecifyActiveMQBroker<TMessage, TCommand, TEvent, TRequest, TResponse> WithNoLocalFlag();
+    }
+
     internal class ActiveMQFluentConfig<TServiceMessage, TMessage, TCommand, TEvent, TRequest, TResponse> :
         ICanSpecifyActiveMQServiceName<TMessage, TCommand, TEvent, TRequest, TResponse>, 
         ICanCreateEndpointAsClientOrServer<TMessage, TCommand, TEvent, TRequest, TResponse>, 
         ICanSpecifyActiveMQQueueAcknowledge<TMessage, TCommand, TEvent, TRequest, TResponse>,
-        ICanSpecifyActiveMQBrokerCredentials<TMessage, TCommand, TEvent, TRequest, TResponse>
+        ICanSpecifyActiveMQBrokerCredentials<TMessage, TCommand, TEvent, TRequest, TResponse>,
+        ICanSpecifyActiveMQNoLocalFlag<TMessage, TCommand, TEvent, TRequest, TResponse>
         where TMessage : class
         where TServiceMessage : class 
         where TCommand : class, TMessage 
@@ -132,12 +144,6 @@ namespace Obvs.ActiveMQ.Configuration
             return this;
         }
 
-        public ICanCreateEndpointAsClientOrServer<TMessage, TCommand, TEvent, TRequest, TResponse> NoLocal()
-        {
-            _noLocal = true;
-            return this;
-        }
-
         public ICanAddEndpointOrLoggingOrCorrelationOrCreate<TMessage, TCommand, TEvent, TRequest, TResponse> AsClient()
         {
             return _canAddEndpoint.WithClientEndpoints(CreateProvider());
@@ -157,8 +163,8 @@ namespace Obvs.ActiveMQ.Configuration
         {
             return new ActiveMQServiceEndpointProvider<TServiceMessage, TMessage, TCommand, TEvent, TRequest, TResponse>(
                 _serviceName, _brokerUri, _serializer, _deserializerFactory, _queueTypes, _assemblyFilter, 
-                _typeFilter, ActiveMQFluentConfigContext.SharedConnection, _brokerSelector, _noLocal, _propertyFilter,
-                _propertyProvider, _userName, _password, _connectionFactoryConfiguration);
+                _typeFilter, ActiveMQFluentConfigContext.SharedConnection, _brokerSelector, _propertyFilter,
+                _propertyProvider, _userName, _password, _connectionFactoryConfiguration, _noLocal);
         }
 
         public ICanSpecifyActiveMQBrokerCredentials<TMessage, TCommand, TEvent, TRequest, TResponse> ConnectToBroker(string brokerUri)
@@ -231,6 +237,12 @@ namespace Obvs.ActiveMQ.Configuration
         public ICanSpecifyActiveMQBroker<TMessage, TCommand, TEvent, TRequest, TResponse> WithConnectionFactoryConfig(Action<ConnectionFactory> connectionFactoryConfiguration)
         {
             _connectionFactoryConfiguration = connectionFactoryConfiguration;
+            return this;
+        }
+
+        public ICanSpecifyActiveMQBroker<TMessage, TCommand, TEvent, TRequest, TResponse> WithNoLocalFlag()
+        {
+            _noLocal = true;
             return this;
         }
     }

--- a/Obvs.ActiveMQ/Configuration/DestinationFactory.cs
+++ b/Obvs.ActiveMQ/Configuration/DestinationFactory.cs
@@ -46,8 +46,8 @@ namespace Obvs.ActiveMQ.Configuration
             Func<Assembly, bool> assemblyFilter = null,
             Func<Type, bool> typeFilter = null,
             string selector = null,
-            bool noLocal = false,
-            AcknowledgementMode mode = AcknowledgementMode.AutoAcknowledge)
+            AcknowledgementMode mode = AcknowledgementMode.AutoAcknowledge,
+            bool noLocal = false)
             where TMessage : class
             where TServiceMessage : class
         {
@@ -55,7 +55,7 @@ namespace Obvs.ActiveMQ.Configuration
                 lazyConnection,
                 deserializerFactory.Create<TMessage, TServiceMessage>(assemblyFilter, typeFilter),
                 CreateDestination(destination, destinationType),
-                mode, selector, noLocal, propertyFilter);
+                mode, selector, propertyFilter, noLocal);
         }
 
         private static IDestination CreateDestination(string name, DestinationType type)

--- a/Obvs.ActiveMQ/MessageSource.cs
+++ b/Obvs.ActiveMQ/MessageSource.cs
@@ -17,28 +17,28 @@ namespace Obvs.ActiveMQ
         where TMessage : class
     {
         private readonly string _selector;
-        private readonly bool _noLocal;
         private readonly Func<IDictionary, bool> _propertyFilter;
         private readonly IDictionary<string, IMessageDeserializer<TMessage>> _deserializers;
         private readonly IDestination _destination;
         private readonly Apache.NMS.AcknowledgementMode _mode;
         private readonly Lazy<IConnection> _lazyConnection;
+        private readonly bool _noLocal;
 
         public MessageSource(Lazy<IConnection> lazyConnection,
             IEnumerable<IMessageDeserializer<TMessage>> deserializers,
             IDestination destination,
             AcknowledgementMode mode = AcknowledgementMode.AutoAcknowledge,
             string selector = null,
-            bool noLocal = false,
-            Func<IDictionary, bool> propertyFilter = null)
+            Func<IDictionary, bool> propertyFilter = null,
+            bool noLocal = false)
         {
             _deserializers = deserializers.ToDictionary(d => d.GetTypeName());
             _lazyConnection = lazyConnection;
             _destination = destination;
             _mode = mode == AcknowledgementMode.ClientAcknowledge ? Apache.NMS.AcknowledgementMode.ClientAcknowledge : Apache.NMS.AcknowledgementMode.AutoAcknowledge;
             _selector = selector;
-            _noLocal = noLocal;
             _propertyFilter = propertyFilter;
+            _noLocal = noLocal;
 
             var messages = Observable.Create<TMessage>(observer =>
                 {

--- a/Obvs.ActiveMQ/TextMessageSource.cs
+++ b/Obvs.ActiveMQ/TextMessageSource.cs
@@ -17,9 +17,9 @@ namespace Obvs.ActiveMQ
         private readonly Encoding _encoding;
 
         public TextMessageSource(Lazy<IConnection> lazyConnection, IEnumerable<IMessageDeserializer<TMessage>> deserializers,
-            IDestination destination, AcknowledgementMode mode = AcknowledgementMode.AutoAcknowledge, string selector = null, bool noLocal = false,
-            Encoding encoding = null, Func<IDictionary, bool> propertyFilter = null)
-            : base(lazyConnection, deserializers, destination, mode, selector, noLocal, propertyFilter)
+            IDestination destination, AcknowledgementMode mode = AcknowledgementMode.AutoAcknowledge, string selector = null, 
+            Encoding encoding = null, Func<IDictionary, bool> propertyFilter = null, bool noLocal = false)
+            : base(lazyConnection, deserializers, destination, mode, selector, propertyFilter, noLocal)
         {
             _encoding = encoding ?? Encoding.UTF8;
         }


### PR DESCRIPTION
Added publicly visible interface to ActiveMQFluentConfig to enable NoLocal flag and reshuffled the noLocal parameter in method signatures (moved to the end) to make sure it won't break existing applications